### PR TITLE
feat(i18n): add i18n for project(#225)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-icons": "^4.3.1",
     "react-infinite-scroll-component": "^6.1.0",
     "react-inspector": "^5.1.1",
+    "react-intl": "^6.2.1",
     "react-picky-date-time": "^1.9.1",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",

--- a/src/components/menu/MainMenu.js
+++ b/src/components/menu/MainMenu.js
@@ -7,7 +7,7 @@ import version from '../../misc/version';
 import {BiChevronLeftCircle, BiChevronRightCircle} from "react-icons/bi";
 import {BsPersonCircle, BsFileEarmarkArrowUp} from "react-icons/bs";
 import {VscOrganization, VscPulse, VscTools} from "react-icons/vsc";
-import {IoGitNetworkSharp} from "react-icons/io5";
+import {IoGitNetworkSharp, IoLanguageOutline} from "react-icons/io5";
 import {GoSettings} from "react-icons/go";
 import {VscLaw, VscDashboard} from "react-icons/vsc";
 import {BsClipboardCheck, BsStar, BsBoxArrowRight, BsBoxArrowInRight} from "react-icons/bs";
@@ -16,8 +16,13 @@ import {useConfirm} from "material-ui-confirm";
 import {asyncRemote, getError} from "../../remote_api/entrypoint";
 import {connect} from "react-redux";
 import {showAlert} from "../../redux/reducers/alertSlice";
+import {changeLanguage} from "../../redux/reducers/localeSlice";
+import Popover from '@mui/material/Popover';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
+import {T} from "../../locale/tool"
 
-function MainMenu({showAlert}) {
+function MainMenu({showAlert, locale, changeLanguage}) {
 
     const [collapsed, setCollapsed] = useState(false);
     const confirm = useConfirm()
@@ -46,6 +51,62 @@ function MainMenu({showAlert}) {
             <div className="MenuRow" onClick={onClick} style={style}><span className="Icon">{icon}</span>{!collapsed && <span className="Label">{label}</span>}</div>
             :
             null
+        )
+    }
+
+    const LanguageRow = ({collapsed}) => {
+        const languageMap = {
+            en: "English",
+            zh: "中文",
+        };
+        const languageName = languageMap[locale.language]
+        const [anchorEl, setAnchorEl] = React.useState(null);
+        const open = Boolean(anchorEl);
+        const id = open ? "language-popover" : undefined;
+
+        const handleClick = (event) => {
+            setAnchorEl(event.currentTarget);
+        };
+        const handleClose = (language = null) => {
+            setAnchorEl(null);
+            if (language) {
+                changeLanguage({language: language})
+            }
+        };
+
+        return (
+          <div>
+              <div className="MenuRow"
+                   onClick={handleClick}
+                   aria-controls={open ? 'composition-menu' : undefined}
+                   aria-expanded={open ? 'true' : undefined}
+                   aria-haspopup="true"
+              >
+                  <span className="Icon"><IoLanguageOutline /></span>{!collapsed && <span className="Label">{languageName}</span>}
+              </div>
+              <Popover id={id}
+                       open={open}
+                       anchorEl={anchorEl}
+                       onClose={() => handleClose()}
+                       anchorOrigin={{
+                           vertical: 'center',
+                           horizontal: 'right',
+                       }}
+                       transformOrigin={{
+                           vertical: 'center',
+                           horizontal: 'left',
+                       }}
+              >
+                  <MenuList
+                    autoFocusItem={open}
+                    id="composition-menu"
+                    aria-labelledby={id}
+                  >
+                      <MenuItem onClick={() => handleClose('en')}>English</MenuItem>
+                      <MenuItem onClick={() => handleClose('zh')}>简体中文</MenuItem>
+                  </MenuList>
+              </Popover>
+          </div>
         )
     }
 
@@ -86,7 +147,7 @@ function MainMenu({showAlert}) {
         <div>
             <Branding collapsed={collapsed}/>
             <div>
-                <MenuRow icon={<VscDashboard size={20}/>} label="Dashboard" collapsed={collapsed} onClick={go("/dashboard")} roles={["admin", "developer", "marketer", "maintainer"]} style={{marginBottom: 20}}/>
+                <MenuRow icon={<VscDashboard size={20}/>} label={T("app.menu.dashboard")} collapsed={collapsed} onClick={go("/dashboard")} roles={["admin", "developer", "marketer", "maintainer"]} style={{marginBottom: 20}}/>
 
                 <MenuRow icon={<BsBoxArrowInRight size={20}/>} label="Inbound Traffic" collapsed={collapsed} onClick={go("/inbound")} roles={["admin", "developer"]}/>
                 <MenuRow icon={<BsFolder size={20}/>} label="Data" collapsed={collapsed} onClick={go("/data")} roles={["admin", "developer", "marketer"]}/>
@@ -121,6 +182,7 @@ function MainMenu({showAlert}) {
                      onClick={go("/maintenance")}
                      roles={["admin", "maintainer"]}/>
             <MenuRow icon={<BsFileEarmarkArrowUp size={20}/>} label="Import" collapsed={collapsed} onClick={go("/import")} roles={["admin", "developer"]}/>
+            <LanguageRow collapsed={collapsed} />
             <MenuRow icon={<GoSettings size={20}/>}
                      label="Settings"
                      collapsed={collapsed}
@@ -140,10 +202,11 @@ function MainMenu({showAlert}) {
 
 const mapProps = (state) => {
     return {
+        locale: state.localeReducer,
         notification: state.notificationReducer,
     }
 };
 export default connect(
     mapProps,
-    {showAlert}
+    {showAlert, changeLanguage}
 )(MainMenu);

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,13 @@ import reportWebVitals from './reportWebVitals';
 import store from './redux/store'
 import {Provider} from "react-redux";
 import App from "./components/App";
-import {mainTheme} from "./themes";
-import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
+import { StyledEngineProvider } from "@mui/material/styles";
 import {ConfirmProvider} from "material-ui-confirm";
 import Installer from "./components/Installer";
 import ApiUrlSelector from "./components/ApiUrlSelector";
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
+import Intl from "./locale"
 
 if (!process.env.NODE_ENV || process.env.NODE_ENV !== 'development') {
     Sentry.init({
@@ -31,7 +31,7 @@ ReactDOM.render(
     <React.StrictMode>
         <Provider store={store}>
             <StyledEngineProvider injectFirst>
-                <ThemeProvider theme={mainTheme}>
+                <Intl>
                     <CssBaseline/>
                     <ConfirmProvider>
                         <ApiUrlSelector>
@@ -40,7 +40,7 @@ ReactDOM.render(
                             </Installer>
                         </ApiUrlSelector>
                     </ConfirmProvider>
-                </ThemeProvider>
+                </Intl>
             </StyledEngineProvider>
         </Provider>
     </React.StrictMode>,

--- a/src/locale/index.js
+++ b/src/locale/index.js
@@ -1,0 +1,75 @@
+import React from "react";
+import { connect } from "react-redux";
+import { IntlProvider } from "react-intl";
+
+import { enUS, zhCN } from "@mui/material/locale"
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+
+import zh_CN from "./lang/zh_CN";
+import en_US from "./lang/en_US";
+import { mainTheme } from "../themes";
+
+
+const flattenMessages = (nestedMessages, prefix = "") => {
+  if (nestedMessages === null) {
+    return {}
+  }
+  return Object.keys(nestedMessages).reduce((messages, key) => {
+    const value = nestedMessages[key]
+    const prefixedKey = prefix ? `${prefix}.${key}` : key
+
+    if (typeof value === "string") {
+      Object.assign(messages, { [prefixedKey]: value })
+    } else {
+      Object.assign(messages, flattenMessages(value, prefixedKey))
+    }
+
+    return messages
+  }, {})
+}
+
+const chooseLocale = (language) => {
+  let _language = language || navigator.language.split("_")[0]
+  switch (_language) {
+    case "en":
+      return en_US
+    case "zh":
+      return zh_CN
+    default:
+      return en_US
+  }
+}
+
+const chooseThemeLocale = (language) => {
+  let _language = language || navigator.language.split("_")[0]
+  switch (_language) {
+    case "en":
+      return {...mainTheme, enUS}
+    case "zh":
+      return {...mainTheme, zhCN}
+    default:
+      return {...mainTheme, enUS}
+  }
+}
+
+const mapState = (state) => {
+  return {
+    locale: state.localeReducer.language,
+    localeTheme: chooseThemeLocale(state.localeReducer.language),
+    localeMessage: chooseLocale(state.localeReducer.language),
+  }
+}
+
+const Index = (props) => {
+  const { locale, localeTheme, localeMessage, children } = props
+
+  return (
+      <IntlProvider locale={locale} messages={flattenMessages(localeMessage)}>
+        <ThemeProvider theme={createTheme(localeTheme)}>
+          {children}
+        </ThemeProvider>
+      </IntlProvider>
+  )
+}
+
+export default connect(mapState)(Index)

--- a/src/locale/lang/en_US.js
+++ b/src/locale/lang/en_US.js
@@ -1,0 +1,9 @@
+const en_US = {
+  app: {
+    menu: {
+      dashboard: "Dashboard"
+    }
+  }
+}
+
+export default en_US

--- a/src/locale/lang/zh_CN.js
+++ b/src/locale/lang/zh_CN.js
@@ -1,0 +1,9 @@
+const zh_CN = {
+  app: {
+    menu: {
+      dashboard: "概览"
+    }
+  }
+}
+
+export default zh_CN

--- a/src/locale/tool.js
+++ b/src/locale/tool.js
@@ -1,0 +1,6 @@
+import { useIntl } from "react-intl"
+
+export const T = (id) => {
+  const intl = useIntl()
+  return intl.formatMessage({id: id})
+}

--- a/src/redux/reducers/localeSlice.js
+++ b/src/redux/reducers/localeSlice.js
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit"
+
+import storageValue from "../../misc/localStorageDriver"
+
+export const locale = createSlice({
+  name: "locale",
+  initialState: {
+    language: new storageValue("tracardi-language").read("en"),
+  },
+  reducers: {
+    changeLanguage: (state,  {payload}) => {
+      if (["zh", "en"].includes(payload.language)) {
+        state.language = payload.language
+        new storageValue("tracardi-language").save(payload.language)
+      } else {
+        state.language = "en"
+        new storageValue("tracardi-language").save("en")
+      }
+    },
+  },
+})
+
+export const { changeLanguage } = locale.actions
+export default locale.reducer

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -8,6 +8,7 @@ import progressReducer from "./reducers/progressSlice";
 import newResource from "./reducers/newResource";
 import uqlReducer from "./reducers/uqlSlice";
 import pagingReducer from "./reducers/pagingSlice";
+import localeReducer from "./reducers/localeSlice";
 
 export default configureStore({
         reducer: {
@@ -20,6 +21,7 @@ export default configureStore({
             newResource,
             uqlReducer,
             pagingReducer,
+            localeReducer,
         }
     }
 );

--- a/src/themes.js
+++ b/src/themes.js
@@ -1,6 +1,39 @@
 import { createTheme} from '@mui/material/styles';
 
-export const mainTheme = createTheme({
+// export const mainTheme = createTheme({
+//     typography: {
+//         "fontFamily": `"IBM Plex Sans", "Arial", sans-serif`,
+//         "fontSize": 15,
+//         "fontWeightLight": 300,
+//         "fontWeightRegular": 400,
+//         "fontWeightMedium": 500
+//     },
+//     palette: {
+//         primary: {
+//             main: '#1976d2',
+//         },
+//         secondary: {
+//             main: '#EF6C00',
+//         },
+//         error: {
+//             main: "#d81b60",
+//         },
+//         success: {
+//             main: "#43a047",
+//         },
+//         gray: {
+//             main: "#ccc",
+//         },
+//         background: {
+//             default: '#ccc',
+//         },
+//         text: {
+//             primary: '#000'
+//         }
+//     },
+// });
+
+export const mainTheme = {
     typography: {
         "fontFamily": `"IBM Plex Sans", "Arial", sans-serif`,
         "fontSize": 15,
@@ -31,7 +64,7 @@ export const mainTheme = createTheme({
             primary: '#000'
         }
     },
-});
+};
 
 export const signInTheme = createTheme({
     palette: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,76 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@formatjs/ecma402-abstract@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.13.0.tgz#df6db3cbee0182bbd2fd6217103781c802aee819"
+  integrity sha512-CQ8Ykd51jYD1n05dtoX6ns6B9n/+6ZAxnWUAonvHC4kkuAemROYBhHkEB4tm1uVrRlE7gLDqXkAnY51Y0pRCWQ==
+  dependencies:
+    "@formatjs/intl-localematcher" "0.2.31"
+    tslib "2.4.0"
+
+"@formatjs/fast-memoize@1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-1.2.6.tgz#a442970db7e9634af556919343261a7bbe5e88c3"
+  integrity sha512-9CWZ3+wCkClKHX+i5j+NyoBVqGf0pIskTo6Xl6ihGokYM2yqSSS68JIgeo+99UIHc+7vi9L3/SDSz/dWI9SNlA==
+  dependencies:
+    tslib "2.4.0"
+
+"@formatjs/icu-messageformat-parser@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.10.tgz#d11114343fcb4c6d5ccabdeac50badf49c83fd9e"
+  integrity sha512-KkRMxhifWkRC45dhM9tqm0GXbb6NPYTGVYY3xx891IKc6p++DQrZTnmkVSNNO47OEERLfuP2KkPFPJBuu8z/wg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/icu-skeleton-parser" "1.3.14"
+    tslib "2.4.0"
+
+"@formatjs/icu-skeleton-parser@1.3.14":
+  version "1.3.14"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.14.tgz#b99ef7f855f8a58cab2519ec4f921f11c2bf74a7"
+  integrity sha512-7bv60HQQcBb3+TSj+45tOb/CHV5z1hOpwdtS50jsSBXfB+YpGhnoRsZxSRksXeCxMy6xn6tA6VY2601BrrK+OA==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.13.0"
+    tslib "2.4.0"
+
+"@formatjs/intl-displaynames@6.1.4":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-displaynames/-/intl-displaynames-6.1.4.tgz#26b2c7b814f5132b2e6d781bf4af7bce86f46852"
+  integrity sha512-sEbziGLsWQo6nA8ZUBcsDRlZzPg+uMVjDmbTalgGqRWLbdXuxMldTYdaCK+UptyJhkmNVM/erz3csTiyqamXHQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/intl-localematcher" "0.2.31"
+    tslib "2.4.0"
+
+"@formatjs/intl-listformat@7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-7.1.3.tgz#e2bda750a46d2a90d7fa023b02a984588978829c"
+  integrity sha512-rs0Kxl78PeRCedx2cmFoBqcun2Kf0bCQrF8ycna54sfePpDhMskvODWeI4G/xBioW01FjK7CJSvtJJ87hrr79A==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/intl-localematcher" "0.2.31"
+    tslib "2.4.0"
+
+"@formatjs/intl-localematcher@0.2.31":
+  version "0.2.31"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.31.tgz#aada2b1e58211460cedba56889e3c489117eb6eb"
+  integrity sha512-9QTjdSBpQ7wHShZgsNzNig5qT3rCPvmZogS/wXZzKotns5skbXgs0I7J8cuN0PPqXyynvNVuN+iOKhNS2eb+ZA==
+  dependencies:
+    tslib "2.4.0"
+
+"@formatjs/intl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl/-/intl-2.5.1.tgz#7a743c3f5ca70b7c7881d6e67e5ce14e2fffac2a"
+  integrity sha512-P01ZGuDDlcN8bHHBCEHspJPvs8WJeO8SXlUIcVGWhS3IN5vUgz0QKUXcKBFnJbEHhONJ+azlObVwvlDKsE+kUg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/fast-memoize" "1.2.6"
+    "@formatjs/icu-messageformat-parser" "2.1.10"
+    "@formatjs/intl-displaynames" "6.1.4"
+    "@formatjs/intl-listformat" "7.1.3"
+    intl-messageformat "10.2.1"
+    tslib "2.4.0"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz"
@@ -2078,7 +2148,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hoist-non-react-statics@^3.3.0":
+"@types/hoist-non-react-statics@^3.3.0", "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -2208,6 +2278,15 @@
   version "17.0.38"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz"
   integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@16 || 17 || 18":
+  version "18.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.25.tgz#8b1dcd7e56fe7315535a4af25435e0bb55c8ae44"
+  integrity sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -5688,6 +5767,16 @@ internmap@^1.0.0:
   resolved "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz"
   integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
+intl-messageformat@10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-10.2.1.tgz#2f5626db773c82f3038d355f56ac4736ceef362b"
+  integrity sha512-1lrJG2qKzcC1TVzYu1VuB1yiY68LU5rwpbHa2THCzA67Vutkz7+1lv5U20K3Lz5RAiH78zxNztMEtchokMWv8A==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/fast-memoize" "1.2.6"
+    "@formatjs/icu-messageformat-parser" "2.1.10"
+    tslib "2.4.0"
+
 ip@^1.1.0:
   version "1.1.5"
   resolved "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz"
@@ -8283,6 +8372,22 @@ react-inspector@^5.1.1:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
+react-intl@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-6.2.1.tgz#976a44f86a58270d1e498d09636b0ece63ad0344"
+  integrity sha512-hYxcSamgoA3Mvc55nwhTF1v15T0NUSkaV/EScMNVZXg0kRyaMAoNHkCi9/9H+TnXWNiWrcWH9bjlMlJwrG2V7g==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.13.0"
+    "@formatjs/icu-messageformat-parser" "2.1.10"
+    "@formatjs/intl" "2.5.1"
+    "@formatjs/intl-displaynames" "6.1.4"
+    "@formatjs/intl-listformat" "7.1.3"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/react" "16 || 17 || 18"
+    hoist-non-react-statics "^3.3.2"
+    intl-messageformat "10.2.1"
+    tslib "2.4.0"
+
 react-is@^16.10.2, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -9601,6 +9706,11 @@ tsconfig-paths@^3.12.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
**Notice: this PR just a simple template of i18n solution for tracard-gui.**

what I do:
1. add react-intl as base of i18n solution;
2. create a new path `src/locale` save i18n file;
3. create a new wrap component  in `src/locale/index.js`;
    a. use [Material UI Localization](https://mui.com/material-ui/guides/localization/) solution provide component i18n;
    b. create `src/redux/reducers/localeSlice.js` to save language state(auto save to browser localStorage for cache);
    c. specificnoun please see the code in commite;
4. modify `src/index.js` with the wrap component(I call it `Intl`);
5. create a tool function T in `src/locale/tool.js`, it is used to call [react-intl's formatMessage interface](https://formatjs.io/docs/react-intl/api#formatmessage) more easily(Other react-intl's interfaces can also be wrapped in it later);
6. modify `src/components/menu/MainMenu.js` add a custom MenuRow use to change language(Other pages without menus can add a button in a fixed place in the page, but right now I don't have it implemented.);
7. **I only added one i18n support for Dashboard  in menu, you can experience all of the above by running my branch.**

some questions:
1. if the html title of the site is always the same(as it seems to be now), we can switch the title at the same time as the language switch(maybe always use Tracardi also be ok). But if there is a subsequent need to change the title, we need a better solution.
2. signInTheme is used in sigIn page, I don't use [Material UI Localization](https://mui.com/material-ui/guides/localization/) solution to handle it.
3. I'm not a better React developer, so the whole solution is a bit rough, if there is a more elegant implementatio, please do let me know.

**Finally, this program may not be the best solution, this is just a simple attempt on my part, welcome to discuss.**

 - [x] I hereby declare this contribution to be licenced under the [MIT license](https://opensource.org/licenses/MIT)
