### PR TITLE
Make the enter key and the button have the same effect in some scenarios (#254)

### DIFF
--- a/src/components/ApiUrlSelector.js
+++ b/src/components/ApiUrlSelector.js
@@ -106,6 +106,7 @@ const ApiUrlSelector = ({children}) => {
                         value={apiLocation || apiUrlStorage().read() || ""}
                         options={new storageValue('tracardi-api-urls').read([])}
                         onChange={(v) => setEndpoint(v)}
+                        onEnter={() => {setApiLocation(endpoint)}}
                         errorMessage={progress ? null : apiLocation && (!isEndpointReachable ? "Given API URL is not reachable" : isEndpointValid ? null : "Given API URL is invalid")}
                         />          
                     <Button label="Select"

--- a/src/components/InstallerForm.js
+++ b/src/components/InstallerForm.js
@@ -112,6 +112,7 @@ const InstallerForm = ({requireAdmin, onInstalled, errorMessage}) => {
                         <PasswordInput label="Installation token"
                                        fullWidth={true}
                                        value={data.current.token}
+                                       onEnter={handleClick}
                                        onChange={(ev) => data.current.token = ev.target.value}
                         />
                     </td>
@@ -130,11 +131,13 @@ const InstallerForm = ({requireAdmin, onInstalled, errorMessage}) => {
                         <td style={{width: "50%"}}><Input
                             label="Valid e-mail"
                             initValue=""
+                            onEnter={handleClick}
                             onChange={(ev) => data.current.username = ev.target.value}/>
                         </td>
                         <td style={{width: "50%"}}><PasswordInput
                             value={data.current.password}
                             onChange={(ev) => data.current.password = ev.target.value}
+                            onEnter={handleClick}
                             fullWidth={true}/>
                         </td>
                     </tr>

--- a/src/components/authentication/SignIn.js
+++ b/src/components/authentication/SignIn.js
@@ -200,6 +200,11 @@ const SignInForm = ({showAlert}) => {
                                 autoComplete="email"
                                 size="small"
                                 autoFocus
+                                onKeyPress={async (event) => {
+                                    if (event.key === "Enter") {
+                                        await handleSubmit()
+                                    }
+                                }}
                                 onChange={handleEmailChange}/>
                             <PasswordInput
                                 fullWidth={true}
@@ -207,6 +212,7 @@ const SignInForm = ({showAlert}) => {
                                 id="password"
                                 autoComplete="current-password"
                                 onChange={handlePassChange}
+                                onEnter={handleSubmit}
                                 required={true}
                             />
                             <Button

--- a/src/components/elements/forms/inputs/Input.js
+++ b/src/components/elements/forms/inputs/Input.js
@@ -3,7 +3,7 @@ import TextField from "@mui/material/TextField";
 import makeStyles from '@mui/styles/makeStyles';
 import PropTypes from 'prop-types';
 
-export default function Input({onEnterPressed, onChange, label, initValue, error, variant}) {
+export default function Input({onEnterPressed, onChange, onEnter, label, initValue, error, variant}) {
     const useStyles = makeStyles(() => (
         {
             root: {
@@ -38,6 +38,11 @@ export default function Input({onEnterPressed, onChange, label, initValue, error
                    error={error}
                    variant={variant}
                    size="small"
+                   onKeyPress={(event) => {
+                       if (onEnter && event.key === "Enter") {
+                           onEnter()
+                       }
+                   }}
         />
     </div>
 }

--- a/src/components/elements/forms/inputs/PasswordInput.js
+++ b/src/components/elements/forms/inputs/PasswordInput.js
@@ -3,7 +3,7 @@ import React, {useState} from "react";
 import {BsEye, BsEyeSlashFill} from "react-icons/bs";
 import TextField from "@mui/material/TextField";
 
-export default function PasswordInput({label = "Password", value, onChange, fullWidth = false, error, helperText, style, required}) {
+export default function PasswordInput({label = "Password", value, onChange, onEnter, fullWidth = false, error, helperText, style, required}) {
     const [showPassword, setShowPassword] = useState(false);
     const [data, setData] = useState(value);
 
@@ -46,5 +46,10 @@ export default function PasswordInput({label = "Password", value, onChange, full
         }}
         label={label}
         variant="outlined"
+        onKeyPress={(event) => {
+            if (onEnter && event.key === "Enter") {
+                onEnter()
+            }
+        }}
     />
 }

--- a/src/components/elements/tui/TuiApiUrlInput.js
+++ b/src/components/elements/tui/TuiApiUrlInput.js
@@ -2,7 +2,7 @@ import TextField from "@mui/material/TextField";
 import Autocomplete from "@mui/material/Autocomplete";
 import React, {useState} from "react";
 
-export default function TuiApiUrlInput({value, options, label, placeholder="http://localhost:8686", onChange, errorMessage=null, fullWidth=true}) {
+export default function TuiApiUrlInput({value, options, label, placeholder="http://localhost:8686", onChange, onEnter, errorMessage=null, fullWidth=true}) {
 
     const [endpoint, setEndpoint] = useState(value);
 
@@ -31,6 +31,11 @@ export default function TuiApiUrlInput({value, options, label, placeholder="http
                 FormHelperTextProps={{ style: { color: "#d81b60" }}}
                 error={errorMessage!==null}
                 placeholder={placeholder}
+                onKeyPress={(event) => {
+                    if (onEnter && event.key === "Enter") {
+                        onEnter()
+                    }
+                }}
             />
         )}
     />


### PR DESCRIPTION
Make the enter key and the button have the same effect when
1. focuse on ApiUrlSelector page's input
2. focuse on Installer page's input
3. focuse on Sign In page's input

 - [x] I hereby declare this contribution to be licenced under the [MIT license](https://opensource.org/licenses/MIT)
